### PR TITLE
Test 8.0.32 first

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,21 @@ on:
     branches: [ "main" ]
 
 jobs:
+  test_8_0_32:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.test1.outputs.x }}
+    steps:
+    - uses: actions/checkout@v3
+    - id: test1
+      name: Perfromance Tests mysql-connector-odbc-8.0.32
+      run: |
+        docker-compose down
+        docker-compose build --build-arg odbcdlurl=https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.32-linux-glibc2.28-x86-64bit.tar.gz
+        docker-compose up --abort-on-container-exit
+        dlogs=$(docker-compose logs --no-log-prefix --no-color test | tail -1)
+        echo "x=$dlogs" >> $GITHUB_OUTPUT
+
   test_8_0_19:
     runs-on: ubuntu-latest
     outputs:
@@ -22,32 +37,17 @@ jobs:
         dlogs=$(docker-compose logs --no-log-prefix --no-color test | tail -1)
         echo "x=$dlogs" >> $GITHUB_OUTPUT
   
-  test_8_0_32:
-      runs-on: ubuntu-latest
-      outputs:
-        runtime: ${{ steps.test1.outputs.x }}
-      steps:
-      - uses: actions/checkout@v3
-      - id: test1
-        name: Perfromance Tests mysql-connector-odbc-8.0.32
-        run: |
-          docker-compose down
-          docker-compose build --build-arg odbcdlurl=https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.32-linux-glibc2.28-x86-64bit.tar.gz
-          docker-compose up --abort-on-container-exit
-          dlogs=$(docker-compose logs --no-log-prefix --no-color test | tail -1)
-          echo "x=$dlogs" >> $GITHUB_OUTPUT
-  
   comment_on_pr:
       runs-on: ubuntu-latest
       permissions:
         pull-requests: write
       needs: 
-        - test_8_0_19
         - test_8_0_32
+        - test_8_0_19
       steps:
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            mysql-connector-odbc-8.0.19: **${{needs.test_8_0_19.outputs.runtime}}** 
             mysql-connector-odbc-8.0.32: **${{needs.test_8_0_32.outputs.runtime}}**
+            mysql-connector-odbc-8.0.19: **${{needs.test_8_0_19.outputs.runtime}}** 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # MySQL-Connector-ODBC-Performance-Testing
 Testing Bugs as reported on https://bugs.mysql.com/bug.php?id=107745
 
-test4
+test5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # MySQL-Connector-ODBC-Performance-Testing
 Testing Bugs as reported on https://bugs.mysql.com/bug.php?id=107745
 
-test1
+test2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # MySQL-Connector-ODBC-Performance-Testing
 Testing Bugs as reported on https://bugs.mysql.com/bug.php?id=107745
 
-test2
+test3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # MySQL-Connector-ODBC-Performance-Testing
 Testing Bugs as reported on https://bugs.mysql.com/bug.php?id=107745
 
-test3
+test4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # MySQL-Connector-ODBC-Performance-Testing
 Testing Bugs as reported on https://bugs.mysql.com/bug.php?id=107745
+
+test1


### PR DESCRIPTION
This PR automatically runs the performance tests to test the MySQL Bug #107745.
https://bugs.mysql.com/bug.php?id=107745

We test the latest version of the connector first in this PR to prove that the ordering of the performance tests are relevant. 